### PR TITLE
87: [Data.RS] Exceptions if geometries are missing

### DIFF
--- a/org.polymap.p4/src/org/polymap/p4/layer/LayersPanel.java
+++ b/org.polymap.p4/src/org/polymap/p4/layer/LayersPanel.java
@@ -25,9 +25,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.beans.PropertyChangeEvent;
 
-import org.geotools.data.DataAccess;
-import org.opengis.feature.type.FeatureType;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -46,8 +43,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 
-import org.polymap.core.data.pipeline.DataSourceDescription;
-import org.polymap.core.data.util.NameImpl;
+import org.polymap.core.catalog.resolve.IResourceInfo;
 import org.polymap.core.mapeditor.MapViewer;
 import org.polymap.core.operation.DefaultOperation;
 import org.polymap.core.operation.OperationSupport;
@@ -176,13 +172,11 @@ public class LayersPanel
 
     protected boolean canBeVisible( ILayer layer ) {
         try {
-            Optional<DataSourceDescription> dsd = P4Plugin.allResolver().connectLayer( layer, new NullProgressMonitor());
-            if (dsd.isPresent() && dsd.get().service.get() instanceof DataAccess) {
-                FeatureType schema = P4Plugin.localCatalog().localFeaturesStore().getSchema( new NameImpl( dsd.get().resourceName.get() ) );
-                if (schema != null && schema.getGeometryDescriptor() == null) {
-                    // no geometries, hide it
-                    return false;
-                } // true in all other cases
+            Optional<IResourceInfo> resInfo = P4Plugin.allResolver().resInfo( layer, new NullProgressMonitor() );
+            if (resInfo.isPresent() && (resInfo.get().getBounds() == null || resInfo.get().getBounds().isNull())) {
+                // no geometries, hide it
+                return false;
+                // true in all other cases
             }
         }
         catch (Exception e) {

--- a/org.polymap.p4/src/org/polymap/p4/layer/NewLayerOperation.java
+++ b/org.polymap.p4/src/org/polymap/p4/layer/NewLayerOperation.java
@@ -16,7 +16,6 @@ package org.polymap.p4.layer;
 
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.operation.projection.ProjectionException;
-import org.opengis.feature.type.FeatureType;
 import org.opengis.geometry.BoundingBox;
 
 import org.apache.commons.logging.Log;
@@ -31,7 +30,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
 import org.polymap.core.catalog.resolve.IResourceInfo;
-import org.polymap.core.data.util.NameImpl;
 import org.polymap.core.project.ILayer;
 import org.polymap.core.runtime.UIThreadExecutor;
 import org.polymap.core.runtime.config.Config2;
@@ -130,13 +128,28 @@ public class NewLayerOperation
         // super
         IStatus superResult = super.doWithCommit( monitor, info );
         
-        FeatureType schema = P4Plugin.localCatalog().localFeaturesStore().getSchema( new NameImpl(label.get()) );
-        if (schema.getGeometryDescriptor() != null) {
-            // mab bbox
-            if (superResult.isOK()) {
-                adaptMapBBox( monitor );
+//        boolean hasGeom = true;
+//        // XXX: throws java.lang.IllegalStateException: No method for: org.polymap.core.data.feature.GetFeatureTypeRequest
+//        // but this is the better solution, since it checks also *remote* data
+//        //Optional<PipelineFeatureSource> featureSource = P4Plugin.allResolver().connectLayer( layer.get(), EncodedImageProducer.class, new NullProgressMonitor());
+//        //hasGeom = featureSource.isPresent() && featureSource.get().getSchema() != null && featureSource.get().getSchema().getGeometryDescriptor() != null;
+//        // XXX: checks only local ressources
+//        if (label.isPresent() || !StringUtils.isBlank( res.get().getName())) {
+//            FeatureType schema = P4Plugin.localCatalog().localFeaturesStore().getSchema( new NameImpl(label.get()) );
+//            hasGeom = schema != null && schema.getGeometryDescriptor() != null;
+//        }
+//        if (hasGeom) {
+            if (!res.isPresent()) {
+                res.set( AllResolver.instance().resInfo( layer.get(), monitor ).get() );
             }
-        }
+            ReferencedEnvelope nativeLayerBounds = res.get().getBounds();
+            if (nativeLayerBounds != null && !nativeLayerBounds.isNull()) { 
+                // mab bbox
+                if (superResult.isOK()) {
+                    adaptMapBBox( monitor );
+                }
+            }
+//        }
         return superResult;
     }
 

--- a/org.polymap.p4/src/org/polymap/p4/layer/NewLayerOperation.java
+++ b/org.polymap.p4/src/org/polymap/p4/layer/NewLayerOperation.java
@@ -127,29 +127,17 @@ public class NewLayerOperation
 
         // super
         IStatus superResult = super.doWithCommit( monitor, info );
-        
-//        boolean hasGeom = true;
-//        // XXX: throws java.lang.IllegalStateException: No method for: org.polymap.core.data.feature.GetFeatureTypeRequest
-//        // but this is the better solution, since it checks also *remote* data
-//        //Optional<PipelineFeatureSource> featureSource = P4Plugin.allResolver().connectLayer( layer.get(), EncodedImageProducer.class, new NullProgressMonitor());
-//        //hasGeom = featureSource.isPresent() && featureSource.get().getSchema() != null && featureSource.get().getSchema().getGeometryDescriptor() != null;
-//        // XXX: checks only local ressources
-//        if (label.isPresent() || !StringUtils.isBlank( res.get().getName())) {
-//            FeatureType schema = P4Plugin.localCatalog().localFeaturesStore().getSchema( new NameImpl(label.get()) );
-//            hasGeom = schema != null && schema.getGeometryDescriptor() != null;
-//        }
-//        if (hasGeom) {
+
+        if (superResult.isOK()) {
             if (!res.isPresent()) {
                 res.set( AllResolver.instance().resInfo( layer.get(), monitor ).get() );
             }
             ReferencedEnvelope nativeLayerBounds = res.get().getBounds();
-            if (nativeLayerBounds != null && !nativeLayerBounds.isNull()) { 
+            if (nativeLayerBounds != null && !nativeLayerBounds.isNull()) {
                 // mab bbox
-                if (superResult.isOK()) {
-                    adaptMapBBox( monitor );
-                }
+                adaptMapBBox( monitor );
             }
-//        }
+        }
         return superResult;
     }
 


### PR DESCRIPTION
@fb71 reicht es nicht vllt. aus, wenn ich den Test nach den _getBounds_, den Du sowieso in adaptMapBBOX drin hast, einfach in die NewLayerOperation reinziehe? Das hat zumindest bei meinem CSV und beim externen WMS jetzt funktioniert.

Die andere Methode mit dem connectLayer funktioniert nicht, weil ich aus der PipelineFeatureSource den FeatureType nicht rausbekomme. Dort müsste ich noch den GetFeatureTypeRequest implementieren, das würde ich aber gern vermeiden.
